### PR TITLE
Use os.path.join instead of string concatenation.

### DIFF
--- a/shellstreaming/test/inputstream/test_textfile.py
+++ b/shellstreaming/test/inputstream/test_textfile.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 from nose.tools import *
-import os
 import time
+from os.path import abspath, dirname, join
 from shellstreaming.inputstream.textfile import TextFile
 
 
-TEST_FILE = os.path.abspath(os.path.dirname(__file__)) + '/test_textfile_input01.txt'
+TEST_FILE = join(abspath(dirname(__file__)), 'test_textfile_input01.txt')
 
 
 def test_textfile_usage():


### PR DESCRIPTION
Use `join` in order to create path intelligently on all operating
systems. See: http://docs.python.org/2/library/os.path.html#os.path.join
