### PR TITLE
Improve test coverage for errors.

### DIFF
--- a/shellstreaming/columndef.py
+++ b/shellstreaming/columndef.py
@@ -75,4 +75,4 @@ class ColumnDef(object):
         try:
             return Type(_type)
         except UnsupportedTypeError as e:
-            raise ColumnDefError("%s")
+            raise ColumnDefError("'%s' is invalid for 'type'" % (_type))

--- a/shellstreaming/error.py
+++ b/shellstreaming/error.py
@@ -14,11 +14,7 @@ class BaseError(Exception):
 
 class UnsupportedTypeError(BaseError):
     """An exception raised when unsupported type is used."""
-    def __init__(self, msg):
-        self.msg = msg
-
-    def __str__(self):
-        return self.msg
+    pass
 
 
 class ColumnDefError(BaseError):

--- a/shellstreaming/test/test_recorddef.py
+++ b/shellstreaming/test/test_recorddef.py
@@ -5,6 +5,12 @@ from shellstreaming.recorddef import RecordDef
 from shellstreaming.type import Type
 
 
+def assert_error_message(error_class, message, func, *args, **kwargs):
+    with assert_raises(error_class) as context:
+        func(*args, **kwargs)
+    eq_(str(context.exception), message)
+
+
 def test_recorddef_usage():
     """Shows how to use RecordDef class."""
     rdef = RecordDef([
@@ -19,38 +25,45 @@ def test_recorddef_usage():
     eq_(rdef[0].type, Type('STRING'))
 
 
-@raises(RecordDefError)
-def test_recorddef_required_key_lacks():
-    rdef = RecordDef([
-        {
-        },  # at least 'name' is required
-    ])
+def test_recorddef_required_key_not_present_raises_error():
+    assert_error_message(RecordDefError,
+                         "In column 0: Key 'name' is required",
+                         RecordDef,
+                         [
+                            {}
+                         ])
 
 
-@raises(RecordDefError)
-def test_recorddef_unsupported_key():
-    rdef = RecordDef([
-        {
-            'name': 'col0',
-            'xyz' : 'yeah',
-        },
-    ])
+def test_recorddef_unsupported_key_raises_error():
+    assert_error_message(RecordDefError,
+                         "In column 0: Key 'xyz' is invalid",
+                         RecordDef,
+                         [
+                             {
+                                 'name': 'col0',
+                                 'xyz' : 'yeah',
+                             },
+                         ])
 
 
-@raises(RecordDefError)
-def test_recorddef_name_invalid():
-    rdef = RecordDef([
-        {
-            'name': 'invalid-col',
-        },
-    ])
+def test_recorddef_invalid_name_value_raises_error():
+    assert_error_message(RecordDefError,
+                         "In column 0: 'invalid-col' is invalid for 'name'",
+                         RecordDef,
+                         [
+                             {
+                                 'name': 'invalid-col',
+                             },
+                         ])
 
 
-@raises(RecordDefError)
 def test_recorddef_type_invalid():
-    rdef = RecordDef([
-        {
-            'name': 'col0',
-            'type': 'SUPER_TYPE'
-        },
-    ])
+    assert_error_message(RecordDefError,
+                         "In column 0: 'SUPER_TYPE' is invalid for 'type'",
+                         RecordDef,
+                         [
+                             {
+                                 'name': 'col0',
+                                 'type': 'SUPER_TYPE'
+                             },
+                         ])

--- a/shellstreaming/test/test_type.py
+++ b/shellstreaming/test/test_type.py
@@ -10,14 +10,17 @@ def test_type_usage():
 
     eq_(Type.equivalent_ss_type(-123), Type('INT'))
 
-
-@raises(UnsupportedTypeError)
 def test_unsupported_type_init():
-    Type('UNSUPPORTED_TYPE')
+    with assert_raises(UnsupportedTypeError) as context:
+        Type('UNSUPPORTED_TYPE')
+    eq_(str(context.exception),
+        'Type UNSUPPORTED_TYPE is not supported as shellstreaming type')
 
-
-@raises(UnsupportedTypeError)
 def test_unsupported_type_equivalent():
     class X:
         pass
-    Type.equivalent_ss_type(X())
+
+    with assert_raises(UnsupportedTypeError) as context:
+        Type.equivalent_ss_type(X())
+    eq_(str(context.exception),
+        "builtin type <type 'instance'> is not convertible to shellstreaming type")

--- a/shellstreaming/type.py
+++ b/shellstreaming/type.py
@@ -50,7 +50,7 @@ class Type:
         """
         builtin_type = type(val)
         if builtin_type not in Type._typemap:
-            raise UnsupportedTypeError("builtin type %s is not convirtible to shellstreaming type" %
+            raise UnsupportedTypeError("builtin type %s is not convertible to shellstreaming type" %
                                        (builtin_type))
         ss_type_str = Type._typemap[builtin_type]
         return Type(ss_type_str)


### PR DESCRIPTION
These commits add test coverage for errors. See individual commit messages for details. In summary:
- Add tests for error and error messages.
- Custom error classes should inherit from `BaseError`, or [be deleted entirely](http://www.youtube.com/watch?v=o9pEzgHorH0).
- Fix missing error message for `ColumnDef` `_gen_type` method.
