### PR TITLE
Add missing package subprocess.api.

### DIFF
--- a/doc/sphinx/tutorial.rst
+++ b/doc/sphinx/tutorial.rst
@@ -43,7 +43,7 @@ shellstreamingの動作には設定ファイルが必要です。
 .. code-block:: bash
 
     $ cd shellstreaming
-    $ support-files/sample-shellstreaming.cnf $HOME/.shellstreaming.cnf
+    $ cp support-files/sample-shellstreaming.cnf $HOME/.shellstreaming.cnf
 
 では、早速アプリケーションを動かします。
 

--- a/shellstreaming/__init__.py
+++ b/shellstreaming/__init__.py
@@ -35,4 +35,5 @@ packages = [
     'shellstreaming.core',
     'shellstreaming.util',
     'shellstreaming.autodeploy',
+    'shellstreaming.api',
 ]

--- a/test/master/test_master_functional.py
+++ b/test/master/test_master_functional.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+
+from subprocess import check_call
+
+
+def test_shellstreaming_help():
+    check_call(["shellstreaming", "--help"])


### PR DESCRIPTION
Missing package caused import error on fresh installs.
- Add test confirming import error.
- Add missing package.

---

Running from the command line after a fresh install caused the following error:

``` sh
$ shellstreaming --help
Traceback (most recent call last):
  File "/usr/local/bin/shellstreaming", line 5, in <module>
    pkg_resources.run_script('shellstreaming==0.1.0', 'shellstreaming')
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/pkg_resources.py", line 489, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/pkg_resources.py", line 1207, in run_script
    execfile(script_filename, namespace, namespace)
  File "/Library/Python/2.7/site-packages/shellstreaming-0.1.0-py2.7.egg/EGG-INFO/scripts/shellstreaming", line 10, in <module>
    from shellstreaming.master.master import main
  File "/Library/Python/2.7/site-packages/shellstreaming-0.1.0-py2.7.egg/shellstreaming/master/master.py", line 32, in <module>
    from shellstreaming import api
ImportError: cannot import name api
```
